### PR TITLE
Retain Pingboard state in configuration queue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ If the Pingboard is available, all settings will be written in their order of ap
 
 Please note that the key index is one-based.
 
+On shutdown the daemon will push an the configuration to the queue to retain it during a downtime. 
+To avoid this behaviour set an empty routing key for the configuration.
+
 #### Error message
 
 An error is structured like this:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configuration is done using environment variables:
 The daemon expects a specific setup for RabbitMQ:
 
 * All messages are sent to one single exchange.
-* There are specific routing keys for status updates and key 1 to 4 presses.
+* There are specific routing keys for status updates, key 1 to 4 presses and to retain the configuration during downtime.
 * Configuration is received on a separate queue. Exchange and routing keys can be configured with the environment
   variables.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configuration is done using environment variables:
 * `AMQP_RK_KEY_2`: RabbitMQ routing key for key 2 press (default: `2.key`)
 * `AMQP_RK_KEY_3`: RabbitMQ routing key for key 3 press (default: `3.key`)
 * `AMQP_RK_KEY_4`: RabbitMQ routing key for key 4 press (default: `4.key`)
+* `AMQP_RK_CONFIG`: RabbitMQ routing key to retain configuration (default: `pingboard-configuration`)
 * `AMQP_QU_CONFIG`: RabbitMQ queue for configuration updates (default: `pingboard-configuration`)
 
 ## API

--- a/src/app.py
+++ b/src/app.py
@@ -64,6 +64,9 @@ def main():
             LOGGER.info("Keyboard interrupt")
             guard.terminate()
 
+    # Restart ioloop for clean-up
+    ioloop.start()
+
     # Teardown
     LOGGER.info("Service terminated")
 

--- a/src/pingboard.py
+++ b/src/pingboard.py
@@ -220,7 +220,10 @@ class PingboardConfiguration(object):
     """Handle Pingboard configuration requests"""
     def __init__(self, pb_serial: PingboardSerial):
         self._serial = pb_serial
-        self._state = PingboardState()
+
+        # State object will be created when the first configuration comes in.
+        # This way we won't push dummy configuration to the board.
+        self._state = None
 
         self._cfg_handlers = {
             "brightness": self._cfg_brightness,
@@ -229,6 +232,9 @@ class PingboardConfiguration(object):
         }
 
     def push_config(self):
+        if self._state is None:
+            return None
+
         self._brightness(self._state.brightness)
         for idx in range(1, 5):
             key = self._state.keys[idx - 1]
@@ -236,6 +242,9 @@ class PingboardConfiguration(object):
             self._key_blink(idx, key.blink_mode, key.blink_color)
 
     def on_configuration(self, cfg: json):
+        if self._state is None:
+            self._state = PingboardState()
+
         configuration = cfg.get("configuration", dict())
         for key, value in configuration.items():
             try:

--- a/src/pingboard.py
+++ b/src/pingboard.py
@@ -114,6 +114,19 @@ class PingboardKeyState(object):
         self.blink_mode = 'OFF'
         self.blink_color = [0] * 3
 
+    def as_key_configuration(self, idx: int) -> dict:
+        return {
+            "idx": idx,
+            "color": self.color
+        }
+
+    def as_blink_configuration(self, idx: int) -> dict:
+        return {
+            "idx": idx,
+            "mode": self.blink_mode,
+            "color": self.blink_color
+        }
+
 
 class PingboardState(object):
     """Store the Pingboard configuration state"""
@@ -124,6 +137,15 @@ class PingboardState(object):
                      PingboardKeyState(),
                      PingboardKeyState()]
         self.brightness = 255
+
+    def as_configuration(self) -> dict:
+        return {
+            "configuration": {
+                "brightness": self.brightness,
+                "keys": [key.as_key_configuration(idx + 1) for idx, key in enumerate(self.keys)],
+                "blink": [key.as_blink_configuration(idx + 1) for idx, key in enumerate(self.keys)]
+            },
+        }
 
 
 class PingboardSerial:
@@ -220,6 +242,9 @@ class PingboardConfiguration(object):
                 self._cfg_handlers[key](value)
             except Exception as e:
                 LOGGER.error("Invalid configuration snippet: %s", str(e))
+
+    def get_configuration(self) -> dict:
+        return self._state.as_configuration()
 
     def _cfg_brightness(self, brightness):
         if brightness is not None:

--- a/src/rabbitmq.py
+++ b/src/rabbitmq.py
@@ -20,6 +20,7 @@ class AmqpConfiguration(object):
     DEFAULT_EXCHANGE = "pingboard"
     DEFAULT_RK_STATUS = "status"
     DEFAULT_RK_KEY = ['1.key', '2.key', '3.key', '4.key']
+    DEFAULT_RK_CONFIGURATION = "pingboard-configuration"
     DEFAULT_QU_CONFIGURATION = "pingboard-configuration"
 
     @staticmethod
@@ -33,10 +34,12 @@ class AmqpConfiguration(object):
         rk_key = [""] * 4
         for i in range(0, 4):
             rk_key[i] = os.getenv('AMQP_RK_KEY_{}'.format(1), AmqpConfiguration.DEFAULT_RK_KEY[i])
+        rk_config = os.getenv('AMQP_RK_CONFIG', AmqpConfiguration.DEFAULT_RK_CONFIGURATION)
         qu_config = os.getenv('AMQP_QU_CONFIG', AmqpConfiguration.DEFAULT_QU_CONFIGURATION)
 
         return AmqpConfiguration(host, user, passwd,
-                                 exchange, rk_status, rk_key, qu_config)
+                                 exchange, rk_status, rk_key,
+                                 rk_config, qu_config)
 
     def __init__(self,
                  amqp_host: str,
@@ -45,6 +48,7 @@ class AmqpConfiguration(object):
                  exchange: Optional[str] = DEFAULT_EXCHANGE,
                  rk_status: Optional[str] = DEFAULT_RK_STATUS,
                  rk_key: Optional[List[str]] = None,
+                 rk_config: Optional[str] = DEFAULT_RK_CONFIGURATION,
                  qu_config: Optional[str] = DEFAULT_QU_CONFIGURATION):
 
         if not amqp_host:
@@ -66,6 +70,7 @@ class AmqpConfiguration(object):
         self._exchange = exchange
         self._rk_status = rk_status
         self._rk_key = rk_key or AmqpConfiguration.DEFAULT_RK_KEY
+        self._rk_config = rk_config
         self._qu_config = qu_config
 
     def host(self) -> str:
@@ -85,6 +90,9 @@ class AmqpConfiguration(object):
 
     def rk_key(self, idx: int) -> str:
         return self._rk_key[idx]
+
+    def rk_config(self) -> str:
+        return self._rk_config
 
     def qu_config(self) -> str:
         return self._qu_config


### PR DESCRIPTION
When the daemon is stopped, send the configuration as a message to the configuration queue so that it can be reloaded when the daemon is started.