### PR TITLE
Cancel docker build on concurrent workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,10 @@ env:
   IMAGE_NAME: mrtux/pingboard-daemon
   TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building Docker images by introducing concurrency controls to prevent overlapping workflow runs for the same branch or tag.

Workflow improvements:

* Added a `concurrency` group to `.github/workflows/docker-image.yml` to ensure that only one workflow run is in progress per branch or tag, and to automatically cancel any in-progress runs if a new one is triggered.